### PR TITLE
Speed up algorithm

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,6 @@ function diceCoefficient(value, alternative) {
       if (leftPair === rightPair) {
         intersections++;
         rightIndex = offset + 1;
-
-        /* Make sure this pair never matches again */
-        right[offset] = '';
         break;
       } else if (leftPair < rightPair) {
         rightIndex = offset;

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ module.exports = diceCoefficient;
 
 /* Get the edit-distance according to Dice between two values. */
 function diceCoefficient(value, alternative) {
-  var left = bigrams(String(value).toLowerCase());
-  var right = bigrams(String(alternative).toLowerCase());
+  var left = bigrams(String(value).toLowerCase()).sort();
+  var right = bigrams(String(alternative).toLowerCase()).sort();
   var rightLength = right.length;
   var length = left.length;
   var index = -1;
@@ -15,19 +15,24 @@ function diceCoefficient(value, alternative) {
   var rightPair;
   var leftPair;
   var offset;
+  var rightIndex = 0;
 
   while (++index < length) {
     leftPair = left[index];
-    offset = -1;
+    offset = rightIndex - 1;
 
     while (++offset < rightLength) {
       rightPair = right[offset];
 
       if (leftPair === rightPair) {
         intersections++;
+        rightIndex = offset + 1;
 
         /* Make sure this pair never matches again */
         right[offset] = '';
+        break;
+      } else if (leftPair < rightPair) {
+        rightIndex = offset;
         break;
       }
     }


### PR DESCRIPTION
Firstly, we sort `left` and `right` parts, so we can do less operations, because on `leftPair < rightPair` we can skip this element. The second thing for speed up was using `rightIndex`, because after sorting we can skip first part of `right` before `rightIndex`